### PR TITLE
include VK_KHR_buffer_device_address in EnabledExtensionNames

### DIFF
--- a/src/vk_bevy_instance.rs
+++ b/src/vk_bevy_instance.rs
@@ -162,7 +162,10 @@ impl VkBevyInstance {
             .queue_family_index(queue_family_index as u32)
             .queue_priorities(&[1.0]);
 
-        let device_extension_names = vec![swapchain::NAME.as_ptr()];
+        let device_extension_names = vec![
+            swapchain::NAME.as_ptr(),
+            vk::KHR_BUFFER_DEVICE_ADDRESS_NAME.as_ptr(),
+        ];
 
         let mut physical_device_buffer_device_address_features =
             vk::PhysicalDeviceBufferDeviceAddressFeatures::default();


### PR DESCRIPTION
Using VkPhysicalDeviceBufferDeviceAddressFeatures, but the parent extension (VK_KHR_buffer_device_address) was not included in ppEnabledExtensionNames.

```
Validation Error: [ VUID-VkDeviceCreateInfo-pNext-pNext ] Object 0: handle = 0x22a64f71fa0, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0x901f59ec | vkCreateDevice(): pCreateInfo->pNext<VkPhysicalDeviceBufferDeviceAddressFeatures> includes a pointer to a VkPhysicalDeviceBufferDeviceAddressFeatures, but when creating VkDevice, the parent extension (VK_KHR_buffer_device_address) was not included in ppEnabledExtensionNames. The Vulkan spec states: Each pNext member of any structure (including this one) in the pNext chain must be either NULL or a pointer to a valid struct for extending VkDeviceCreateInfo (https://vulkan.lunarg.com/doc/view/1.3.280.0/windows/1.3-extensions/vkspec.html#VUID-VkDeviceCreateInfo-pNext-pNext)
```