### PR TITLE
Window resize / minimizing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,11 +187,12 @@ fn update(
     // DRAW
     {
         // info!("draw");
-
-        assert_eq!(window.physical_width(), vk_bevy.swapchain_width);
-
         let width = window.physical_width();
         let height = window.physical_height();
+
+        assert_eq!(width, vk_bevy.swapchain_width);
+        assert_eq!(height, vk_bevy.swapchain_height);
+
         vk_bevy.set_viewport(command_buffer, width, height);
 
         vk_bevy.bind_pipeline(
@@ -232,21 +233,18 @@ fn update(
 }
 
 fn resize(
+    windows: Query<&Window>,
     mut events: EventReader<WindowResized>,
     mut vk_bevy: ResMut<VkBevyInstance>,
-    time: Res<Time>,
 ) {
-    if time.elapsed_seconds() < 1.0 {
-        // FIXME: For some reason a resize event is sent on startup
-        return;
-    }
     for event in events.read() {
-        if vk_bevy.swapchain_width == event.width as u32
-            && vk_bevy.swapchain_height == event.height as u32
-        {
-            // FIXME: this will break with multiple windows
-            return;
+        if let Ok(window) = windows.get(event.window) {
+            let width = window.physical_width();
+            let height = window.physical_height();
+            if width != vk_bevy.swapchain_width || height != vk_bevy.swapchain_height {
+                // FIXME: this will break with multiple windows
+                vk_bevy.recreate_swapchain(width, height);
+            }
         }
-        vk_bevy.recreate_swapchain(event.width as u32, event.height as u32);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,12 @@ fn update(
     let begin_frame = Instant::now();
 
     let mut window = windows.single_mut();
+    let width = window.physical_width();
+    let height = window.physical_height();
+    if width == 0 || height == 0 {
+        // If the window is minimized the width and height will be 0. Skip rendering in this case.
+        return;
+    }
 
     // BEGIN
 
@@ -187,8 +193,6 @@ fn update(
     // DRAW
     {
         // info!("draw");
-        let width = window.physical_width();
-        let height = window.physical_height();
 
         assert_eq!(width, vk_bevy.swapchain_width);
         assert_eq!(height, vk_bevy.swapchain_height);
@@ -241,6 +245,9 @@ fn resize(
         if let Ok(window) = windows.get(event.window) {
             let width = window.physical_width();
             let height = window.physical_height();
+            if width == 0 || height == 0 {
+                continue;
+            }
             if width != vk_bevy.swapchain_width || height != vk_bevy.swapchain_height {
                 // FIXME: this will break with multiple windows
                 vk_bevy.recreate_swapchain(width, height);

--- a/src/vk_bevy_instance.rs
+++ b/src/vk_bevy_instance.rs
@@ -162,7 +162,10 @@ impl VkBevyInstance {
             .queue_family_index(queue_family_index as u32)
             .queue_priorities(&[1.0]);
 
-        let device_extension_names = vec![swapchain::NAME.as_ptr()];
+        let device_extension_names = vec![
+            swapchain::NAME.as_ptr(),
+            vk::KHR_BUFFER_DEVICE_ADDRESS_NAME.as_ptr(),
+        ];
 
         let mut physical_device_buffer_device_address_features =
             vk::PhysicalDeviceBufferDeviceAddressFeatures::default();


### PR DESCRIPTION
Based on https://github.com/IceSentry/vkbevy/pull/1 since I can't run without it.

- Use the physical width/height for setting the swap chain size
- Only call recreate_swapchain if either the width or height differs from how it was set initially
- Add additional assert for height before set_viewport (not sure if these are needed)
- If the window is minimized and the width/height is 0 don't try to create a swapchain with that size, and skip rendering.